### PR TITLE
add sourcing components documentation for stock metal suppliers

### DIFF
--- a/docs/4in-Liquid-Rocket/sourcing-components.md
+++ b/docs/4in-Liquid-Rocket/sourcing-components.md
@@ -1,0 +1,23 @@
+# Sourcing Components
+
+## Stock metal
+
+**Suppliers in Ontario**
+
+For a local supplier to make sense it has to be cheaper than McMaster-Carr with a 101% duty.
+
+- [Russel Metals](https://www.russelmetals.com/en/)
+- [Sigma Metals](https://www.sigmametals.ca/)
+- [Mr.Metal](https://mrmetal.ca/products/)
+- [McKinnon Metals](https://mckinnonmetals.com/)
+- [Metal Supermarkets](https://www.metalsupermarkets.com/)
+
+We need these items:
+
+- https://www.mcmaster.com/1610T37/
+- https://www.mcmaster.com/1610T37/
+- https://www.mcmaster.com/9056K42/
+- https://www.mcmaster.com/7392T17/
+- https://www.mcmaster.com/8974K11/
+- https://www.mcmaster.com/8974K82/
+- https://www.mcmaster.com/8974K88/


### PR DESCRIPTION
This pull request includes a new documentation section for sourcing components for the 4-inch Liquid Rocket project. The changes provide a list of suppliers and required items.

Documentation updates:

* [`docs/4in-Liquid-Rocket/sourcing-components.md`](diffhunk://#diff-0228a573ff139e270b7546bcca4611252018da36e1a47f7d8c0048958888de72R1-R23): Added a new section titled "Sourcing Components" with a list of metal suppliers in Ontario and the specific items needed from McMaster-Carr.